### PR TITLE
"Fixed" Shapekey/Modifier Explosion bug. 

### DIFF
--- a/migoto/datahandling.py
+++ b/migoto/datahandling.py
@@ -2680,12 +2680,8 @@ def export_3dmigoto_xxmi(operator, context, object_name, vb_path, ib_path, fmt_p
                     count += len(obj_vbarr)
                     ib = numpy.append(ib, obj_ib)
                     vbarr = numpy.append(vbarr, obj_vbarr)
-<<<<<<< HEAD
-                    offsets[current_name + classification].append((collection, depth, obj_c.name, len(obj_ib)*3, len(obj_vbarr)))
-=======
                     if operator.join_meshes is False:
                         offsets[current_name + classification].append((collection, depth, obj_c.name, len(obj_ib)*3, len(obj_vbarr)))
->>>>>>> 46b3d2f2c8bdf9c04bb8f1550ed02053bec59462
 
             # Must be done to all meshes and then compiled
             # if operator.export_shapekeys and mesh.shape_keys is not None and len(mesh.shape_keys.key_blocks) > 1:

--- a/migoto/datahandling.py
+++ b/migoto/datahandling.py
@@ -2627,7 +2627,7 @@ def export_3dmigoto_xxmi(operator, context, object_name, vb_path, ib_path, fmt_p
                 print(f"Exporting {current_name + classification}...")
                 print(f"Exporting {obj.name}:")
                 ib, vbarr = mesh_to_bin(context, operator, obj, layout, game, translate_normal, translate_tangent, obj, outline_properties)
-                offsets[current_name + classification] = [("", 0, obj.name, len(ib)*3)]
+                offsets[current_name + classification] = [("", 0, obj.name, len(ib)*3,len(vbarr))]
             else:
                 raise Fatal('topology "%s" is not supported for export' % vb.topology)
 
@@ -2648,7 +2648,7 @@ def export_3dmigoto_xxmi(operator, context, object_name, vb_path, ib_path, fmt_p
                     count += len(obj_vbarr)
                     ib = numpy.append(ib, obj_ib)
                     vbarr = numpy.append(vbarr, obj_vbarr)
-                    offsets[current_name + classification].append((collection, depth, obj_c.name, len(obj_ib)*3))
+                    offsets[current_name + classification].append((collection, depth, obj_c.name, len(obj_ib)*3, len(obj_vbarr)))
 
             # Must be done to all meshes and then compiled
             # if operator.export_shapekeys and mesh.shape_keys is not None and len(mesh.shape_keys.key_blocks) > 1:
@@ -2826,12 +2826,12 @@ def generate_mod_folder(path, character_name, offsets, no_ramps, delete_intermed
             if any(len(x) > 1 for x in curr_offsets):
                 last_count = 0
                 old_collection = ""
-                for collection, depth, name, count in offsets[current_name + current_object]:
+                for collection, depth, name, icount, vcount in offsets[current_name + current_object]:
                     if collection != old_collection:
                         collection_list += "\t" * (depth-1) + f"; {collection}\n"
-                    collection_list += "\t" * depth + f"; {name}\n"
-                    collection_list += "\t" * depth + f"drawindexed = {count}, {last_count}, 0\n"
-                    last_count += count
+                    collection_list += "\t" * depth + f"; {name} ({vcount})\n"
+                    collection_list += "\t" * depth + f"drawindexed = {icount}, {last_count}, 0\n"
+                    last_count += icount
                     old_collection = collection
             # Correctly order the collections for the different style of texture
             if game == GameEnum.HonkaiStarRail or game == GameEnum.ZenlessZoneZero:

--- a/migoto/operators.py
+++ b/migoto/operators.py
@@ -1095,8 +1095,6 @@ class ExportAdvancedBatchedOperator(bpy.types.Operator):
                     return False
                 xxmi.destination_path = os.path.join(base_dir, frame_folder)
                 bpy.ops.xxmi.exportadvanced()
-                bpy.ops.object.mode_set(mode = 'EDIT')
-                bpy.ops.object.mode_set(mode = 'OBJECT')
                 print(f"Exported frame {frame + 1 - scene.frame_start}/{scene.frame_end + 1 - scene.frame_start}")
             print(f"Batch export took {time.time() - start_time} seconds")
         except Fatal as e:

--- a/migoto/operators.py
+++ b/migoto/operators.py
@@ -1069,13 +1069,14 @@ class ExportAdvancedBatchedOperator(bpy.types.Operator):
     operations = []
     def invoke(self, context, event):
         scene = bpy.context.scene
+        if bpy.app.version < (4, 1, 0):
+            return context.window_manager.invoke_confirm(operator = self, event = event)
         return context.window_manager.invoke_confirm(operator = self,
-            event=event,
-            # message = f"Exporting {scene.frame_end + 1 - scene.frame_start} copies of the mod. This may take a while. Continue?",
-            # title = "Batch export",
-            # icon = 'WARNING',
-            # confirm_text = "Continue"
-            )
+            event = event,
+            message = f"Exporting {scene.frame_end + 1 - scene.frame_start} copies of the mod. This may take a while. Continue?",
+            title = "Batch export",
+            icon = 'WARNING',
+            confirm_text = "Continue")
 
     def execute(self, context):
         scene = bpy.context.scene

--- a/migoto/operators.py
+++ b/migoto/operators.py
@@ -1071,10 +1071,11 @@ class ExportAdvancedBatchedOperator(bpy.types.Operator):
         scene = bpy.context.scene
         return context.window_manager.invoke_confirm(operator = self,
             event=event,
-            message = f"Exporting {scene.frame_end + 1 - scene.frame_start} copies of the mod. This may take a while. Continue?",
-            title = "Batch export",
-            icon = 'WARNING',
-            confirm_text = "Continue")
+            # message = f"Exporting {scene.frame_end + 1 - scene.frame_start} copies of the mod. This may take a while. Continue?",
+            # title = "Batch export",
+            # icon = 'WARNING',
+            # confirm_text = "Continue"
+            )
 
     def execute(self, context):
         scene = bpy.context.scene
@@ -1094,6 +1095,8 @@ class ExportAdvancedBatchedOperator(bpy.types.Operator):
                     return False
                 xxmi.destination_path = os.path.join(base_dir, frame_folder)
                 bpy.ops.xxmi.exportadvanced()
+                bpy.ops.object.mode_set(mode = 'EDIT')
+                bpy.ops.object.mode_set(mode = 'OBJECT')
                 print(f"Exported frame {frame + 1 - scene.frame_start}/{scene.frame_end + 1 - scene.frame_start}")
             print(f"Batch export took {time.time() - start_time} seconds")
         except Fatal as e:


### PR DESCRIPTION
 ## Shapekey/Modifier Explosion bug
While investigating the issue, I noticed that manually exporting frame by frame was causing the modifier explosions, and that swapping edit and object mode was enough to stop it manually, so I just tried it in code, and it works. I hate, but it's easier than trying to find what was done incorrectly. This issue needed to be fixed, because the mesh was being exported to the buffers, and was not a purely visual bug.

## Changed Invoke_Confirm for 3.6
Docs|.
:- |:-
[3.6 Invoke_Confirm](https://docs.blender.org/api/3.6/bpy.types.WindowManager.html#bpy.types.WindowManager.invoke_confirm) | [4.2 Invoke_Confirm](https://docs.blender.org/api/current/bpy.types.WindowManager.html#bpy.types.WindowManager.invoke_props_dialog)