### PR TITLE
Correct bitangent calculation in exporter.py

### DIFF
--- a/migoto/exporter.py
+++ b/migoto/exporter.py
@@ -619,9 +619,7 @@ class ModExporter:
             norm: NDArray = numpy.empty_like(verts_outline_vector)
             norm[ib_data] = loops_face_normal
             tan: NDArray = unit_vector(pos_buf.data["TANGENT"])
-            bitan: NDArray = pos_buf.data["BITANGENTSIGN"][
-                :, numpy.newaxis
-            ] * numpy.cross(norm, tan)
+            bitan: NDArray = numpy.cross(norm, tan)
             texcoord1_element = tex_buf.layout.get_element(
                 AbstractSemantic(Semantic.TexCoord, 1)
             )


### PR DESCRIPTION
This calculation appears to try and get the bitangentsign with 2 methods and then mutliply them. `pos_buf.data["BITANGENTSIGN"][:, numpy.newaxis] *numpy.cross(norm, tan)`

We only want the result of our direct bitangent sign calculation. It felt obvious on a late review.

note: using `pos_buf.data["BITANGENTSIGN"][:, numpy.newaxis] ` seems to produce a fair but less accurate result.